### PR TITLE
Fix Product type definition mismatch

### DIFF
--- a/frontend/src/types/Product.ts
+++ b/frontend/src/types/Product.ts
@@ -1,7 +1,8 @@
 export interface Product {
-    id: string;
-    name: string;
-    price: number;
-    quantity: number;
-  }
+  id: number;
+  name: string;
+  price: number;
+  quantity: number;
+  category: string;
+}
   


### PR DESCRIPTION
## Summary
- correct the `Product` interface to include `category` and use a numeric id

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846c89ce9788323bc243080c230f386